### PR TITLE
adding php version as requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     },
     "require": {
+        "php" : ">=7.1",
         "stephenhill/base58": "^1.1",
         "paragonie/sodium_compat": "^1.6"
     },


### PR DESCRIPTION
Since you're using return type, and also `void`, we must add as requirement the PHP version ^7.1